### PR TITLE
taskempty bug

### DIFF
--- a/routers/view/task_router.js
+++ b/routers/view/task_router.js
@@ -28,7 +28,7 @@ router.get("/task", (req, res) => {
     })
     .catch((err) => {
       console.error(err);
-      res.send(err);
+      res.sendStatus(500).send();
     });
 });
 


### PR DESCRIPTION
## Summary

- Task 폴더가 비어있을 경우 에러를 res.send 반환하는 것에 따른 task 에러 버그 수정