### PR TITLE
fix:log large data call stack error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42,6 +42,7 @@
         "node-wifi": "^2.0.16",
         "pako": "^2.1.0",
         "play-sound": "^1.1.6",
+        "readline": "^1.3.0",
         "redis": "^4.7.0",
         "reflect-metadata": "^0.2.0",
         "rxjs": "^7.8.1",
@@ -11519,6 +11520,11 @@
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
       }
+    },
+    "node_modules/readline": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/readline/-/readline-1.3.0.tgz",
+      "integrity": "sha512-k2d6ACCkiNYz222Fs/iNze30rRJ1iIicW7JuX/7/cozvih6YCkFZH+J6mAFDVgv0dRBaAyr4jDqC95R2y4IADg=="
     },
     "node_modules/redis": {
       "version": "4.7.0",

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "node-wifi": "^2.0.16",
     "pako": "^2.1.0",
     "play-sound": "^1.1.6",
+    "readline": "^1.3.0",
     "redis": "^4.7.0",
     "reflect-metadata": "^0.2.0",
     "rxjs": "^7.8.1",

--- a/src/modules/apis/log/log.service.ts
+++ b/src/modules/apis/log/log.service.ts
@@ -13,6 +13,7 @@ import * as Query from '@common/interface/db/query';
 import { TaskPayload } from '@common/interface/robot/task.interface';
 import * as path from 'path';
 import * as fs from 'fs';
+import * as readline from 'readline';
 import * as os from 'os';
 import { homedir } from 'os';
 import * as AdmZip from 'adm-zip';
@@ -281,71 +282,95 @@ export class LogService {
     });
   }
 
+  async readLogLines(filePath: string): Promise<string[]> {
+    const lines: string[] = [];
+    const fileStream = fs.createReadStream(filePath, 'utf-8');
+    const rl = readline.createInterface({ input: fileStream });
+  
+    for await (const line of rl) {
+      if (line.trim()) {
+        lines.push(line);
+      }
+    }
+  
+    return lines;
+  }
+
+  async parseLines(line:string, param:any){
+    const logRegex =
+      /^(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}) \[(\w+)](?: \[(\w+)\])? (.+)$/;
+    const match = line.match(logRegex);
+
+    if (match) {
+      const [, time, level, category, text] = match;
+      if (param.levels) {
+        if (!param.levels.includes(level)) return null;
+      }
+
+      if (param.searchType == 'category') {
+        if (param.searchText != '') {
+          if (!category || !category.includes(param.searchText)) {
+            return null;
+          }
+        }
+      } else if (param.searchType == 'log') {
+        if (param.searchText != '') {
+          if (!text.includes(param.searchText)) {
+            return null;
+          }
+        }
+      } else if (param.searchType == 'time') {
+        if (param.searchText != '') {
+          if (!time.includes(param.searchText)) {
+            return null;
+          }
+        }
+      }
+
+        return {
+          time,
+          level,
+          category: category ? category : '',
+          text
+        }
+    }
+  }
+
   async getLogs(
     type: string,
     param: LogReadDto,
   ): Promise<PaginationResponse<any>> {
     try {
       const logPath = homedir() + '/log/' + type;
-      const logdata: any[] = [];
+      const logdata: Array<{
+        time: string;
+        level: string;
+        category: string;
+        text: string;
+      }> = [];
       const dt = new Date(param.startDt);
       const dateEnd = new Date(param.endDt);
       while (dt <= dateEnd) {
         const filePath =
           logPath + '/' + DateUtil.formatDateYYYYMMDD(dt) + '.log';
+          // console.debug(filePath);
         if (fs.existsSync(filePath)) {
-          const data = fs.readFileSync(filePath, 'utf-8');
+          const data = fs.readFileSync(filePath,'utf-8');
           const lines = data.split('\n').filter((line) => line.trim() !== '');
+          const BATCH_SIZE = 100000;
+          const chunks:string[][] = [];
+          for (let i = 0; i < lines.length; i += BATCH_SIZE) {
+            chunks.push(lines.slice(i, i + BATCH_SIZE));
+          }
 
-          // 로그 라인을 파싱
-          const parsedLogs = lines
-            .map((line) => {
-              const logRegex =
-                /^(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}) \[(\w+)](?: \[(\w+)\])? (.+)$/;
-              const match = line.match(logRegex);
-
-              if (match) {
-                const [, time, level, category, text] = match;
-                if (param.levels) {
-                  if (!param.levels.includes(level)) return null;
-                }
-
-                if (param.searchType == 'category') {
-                  if (param.searchText != '') {
-                    if (!category || !category.includes(param.searchText)) {
-                      return null;
-                    }
-                  }
-                } else if (param.searchType == 'log') {
-                  if (param.searchText != '') {
-                    if (!text.includes(param.searchText)) {
-                      return null;
-                    }
-                  }
-                } else if (param.searchType == 'time') {
-                  if (param.searchText != '') {
-                    if (!time.includes(param.searchText)) {
-                      return null;
-                    }
-                  }
-                }
-                return {
-                  time,
-                  level,
-                  category: category ? category : '',
-                  text,
-                };
+          for(const chunk of chunks){
+            for (const line of chunk) {
+              const parsedLine = await this.parseLines(line,param);
+              if(parsedLine){
+                logdata.push(parsedLine)
               }
-              return null; // 일치하지 않는 라인은 무시
-            })
-            .filter((log) => log !== null) as Array<{
-            time: string;
-            level: string;
-            category: string;
-            text: string;
-          }>;
-
-          logdata.push(...parsedLogs);
+            }
+          }
         } else {
           httpLogger.debug(`[LOG] getLogs File not found: ${filePath}`);
         }

--- a/src/modules/sockets/gateway/sockets.gateway.ts
+++ b/src/modules/sockets/gateway/sockets.gateway.ts
@@ -789,14 +789,14 @@ export class SocketGateway
         try {
           const data = _data;
           const json = JSON.parse(data);
-          socketLogger.debug(
-            `[COMMAND] FRS vobsRobots: ${JSON.stringify(json)}`,
-          );
+          // socketLogger.debug(
+          //   `[COMMAND] FRS vobsRobots: ${JSON.stringify(json)}`,
+          // );
           this.server.emit('vobsRobots', stringifyAllValues(json));
         } catch (error) {
-          socketLogger.error(
-            `[COMMAND] FRS vobsRobots: ${JSON.stringify(_data)}, ${errorToJson(error)}`,
-          );
+          // socketLogger.error(
+          //   `[COMMAND] FRS vobsRobots: ${JSON.stringify(_data)}, ${errorToJson(error)}`,
+          // );
         }
       });
 


### PR DESCRIPTION
## 📒 요약
log 데이터가 30MB 이상 넘어가는 경우 데이터 파싱 후 logdata 객체에 담는 부분에서 call stack maximum error 발생.
비동기식으로 바꾸고 데이터를 일괄로 push 하는 것이 아니라 애초에 logdata객체에 push하도록 변경